### PR TITLE
fixes scrolling to desired page position for PageSlideActivity.kt

### DIFF
--- a/app/src/main/java/at/ac/tuwien/caa/docscan/koin/KoinModule.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/koin/KoinModule.kt
@@ -75,7 +75,7 @@ val viewModelModule = module {
     viewModel { DocumentViewerViewModel(get(), get()) }
     viewModel { CreateDocumentViewModel(get()) }
     viewModel { (extras: Bundle) -> EditDocumentViewModel(extras, get()) }
-    viewModel { (extras: Bundle) -> PageSlideViewModel(extras, get(), get()) }
+    viewModel { PageSlideViewModel(get(), get()) }
     viewModel { (extras: Bundle) -> ImageViewModel(extras, get()) }
     viewModel { (extras: Bundle) -> CropViewModel(extras, get(), get(), get()) }
     viewModel { ImagesViewModel(get()) }

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/gallery/PageSlideActivity.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/gallery/PageSlideActivity.kt
@@ -9,7 +9,6 @@ import android.view.View
 import androidx.recyclerview.widget.DiffUtil
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
-import at.ac.tuwien.caa.docscan.BuildConfig
 import at.ac.tuwien.caa.docscan.R
 import at.ac.tuwien.caa.docscan.databinding.ActivityPageSlideBinding
 import at.ac.tuwien.caa.docscan.db.model.Page
@@ -27,13 +26,12 @@ import at.ac.tuwien.caa.docscan.ui.dialog.isPositive
 import at.ac.tuwien.caa.docscan.ui.docviewer.DocumentViewerActivity
 import at.ac.tuwien.caa.docscan.ui.segmentation.SegmentationActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.core.parameter.parametersOf
 import java.util.*
 
 class PageSlideActivity : BaseNoNavigationActivity(), PageImageView.SingleClickListener {
 
     private lateinit var binding: ActivityPageSlideBinding
-    private val viewModel: PageSlideViewModel by viewModel { parametersOf(intent.extras!!) }
+    private val viewModel: PageSlideViewModel by viewModel()
     private val dialogViewModel: DialogViewModel by viewModel()
     private val adapter = PageSlideAdapter()
 
@@ -54,10 +52,6 @@ class PageSlideActivity : BaseNoNavigationActivity(), PageImageView.SingleClickL
         @JvmStatic
         fun newInstance(context: Context, docId: UUID, selectedPageId: UUID?): Intent {
             return Intent(context, PageSlideActivity::class.java).apply {
-//                Always open a new instance, to make sure that the PageSlideActivity always shows
-//                the current selected page:
-                flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
-//                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
                 putExtra(EXTRA_DOCUMENT_ID, docId)
                 putExtra(EXTRA_SELECTED_PAGE_ID, selectedPageId)
             }
@@ -81,6 +75,23 @@ class PageSlideActivity : BaseNoNavigationActivity(), PageImageView.SingleClickL
         binding.slideViewpager.adapter = adapter
         initButtons()
         observe()
+        initLoad(intent.extras)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        initLoad(intent?.extras)
+    }
+
+    /**
+     * Initializes the loading of the requested document by extracting the ids from the [bundle].
+     */
+    private fun initLoad(bundle: Bundle?) {
+        bundle ?: return
+        val docId = bundle.getSerializable(EXTRA_DOCUMENT_ID) as UUID
+        val selectedPageId = bundle.getSerializable(EXTRA_SELECTED_PAGE_ID) as UUID?
+        viewModel.load(docId, selectedPageId)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/gallery/PageSlideViewModel.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/gallery/PageSlideViewModel.kt
@@ -1,29 +1,27 @@
 package at.ac.tuwien.caa.docscan.ui.gallery
 
 import android.net.Uri
-import android.os.Bundle
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.ac.tuwien.caa.docscan.db.model.Page
 import at.ac.tuwien.caa.docscan.db.model.getFileName
-import at.ac.tuwien.caa.docscan.logic.*
+import at.ac.tuwien.caa.docscan.logic.Event
+import at.ac.tuwien.caa.docscan.logic.Failure
+import at.ac.tuwien.caa.docscan.logic.FileHandler
+import at.ac.tuwien.caa.docscan.logic.Success
 import at.ac.tuwien.caa.docscan.repository.DocumentRepository
-import at.ac.tuwien.caa.docscan.ui.gallery.PageSlideActivity.Companion.EXTRA_DOCUMENT_ID
-import at.ac.tuwien.caa.docscan.ui.gallery.PageSlideActivity.Companion.EXTRA_SELECTED_PAGE_ID
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.util.*
 
 class PageSlideViewModel(
-    extras: Bundle,
     val repository: DocumentRepository,
     val fileHandler: FileHandler
 ) : ViewModel() {
 
-    private val docId = extras.getSerializable(EXTRA_DOCUMENT_ID) as UUID
-    private val selectedPageId = extras.getSerializable(EXTRA_SELECTED_PAGE_ID) as UUID?
     val observablePages = MutableLiveData<Pair<List<Page>, Int>>()
     val observableInitCrop = MutableLiveData<Event<Page>>()
     val observableInitRetake = MutableLiveData<Event<Pair<UUID, UUID>>>()
@@ -33,13 +31,12 @@ class PageSlideViewModel(
     val observableError = MutableLiveData<Event<Throwable>>()
 
     private var scrollToSpecificPage = true
+    private var collectorJob: Job? = null
 
-    init {
-        load()
-    }
-
-    private fun load() {
-        viewModelScope.launch {
+    fun load(docId: UUID, selectedPageId: UUID?) {
+        // cancel previous collector jobs
+        collectorJob?.cancel()
+        collectorJob = viewModelScope.launch {
             // TODO: this should be just distinct by the page ids and the number, since changes to the state of the file doesn't matter at this place.
             repository.getDocumentWithPagesAsFlow(docId).collectLatest {
                 it ?: return@collectLatest
@@ -92,7 +89,7 @@ class PageSlideViewModel(
                     observableError.postValue(Event(result.exception))
                 }
                 is Success -> {
-                    observableInitRetake.postValue(Event(Pair(docId, result.data.id)))
+                    observableInitRetake.postValue(Event(Pair(result.data.docId, result.data.id)))
                 }
             }
         }


### PR DESCRIPTION
- fixes issues with existing instances of PageSlideActivity.kt by considering the onNewIntent method which is now called and handled correctly if the PageSlideActivity.kt is started again.


(PageSlideActivity has already defined its launchMode in the AndroidManifest, therefore there is no need to append any further flags to the activity.)