### PR TITLE
fixes recently found issues

### DIFF
--- a/app/src/main/java/at/ac/tuwien/caa/docscan/logic/DocumentViewerLaunchViewType.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/logic/DocumentViewerLaunchViewType.kt
@@ -2,5 +2,5 @@ package at.ac.tuwien.caa.docscan.logic
 
 enum class DocumentViewerLaunchViewType {
     DOCUMENTS,
-    PDFS
+    EXPORTS
 }

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/logic/FileHandler.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/logic/FileHandler.kt
@@ -317,10 +317,18 @@ class FileHandler(private val context: Context, private val storageManager: Stor
         return isInternalSpaceAvailable(NUM_BYTES_REQUIRED_FOR_MIGRATION, getDocumentsFolder())
     }
 
+    /**
+     * @return true if [requiredBytes] are available for [targetFolder]
+     *
+     * Post-Condition: [targetFolder] is created if it does not exist.
+     * (The creation is necessary, otherwise [File.getUsableSpace] may return 0 even if the device
+     * has enough storage available.)
+     */
     private fun isInternalSpaceAvailable(
         @Suppress("SameParameterValue") requiredBytes: Long,
         targetFolder: File
     ): Boolean {
+        targetFolder.createFolderIfNecessary()
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val uuid = storageManager.getUuidForPath(targetFolder)
             val availableBytes = storageManager.getAllocatableBytes(uuid)

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/logic/notification/NotificationHandler.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/logic/notification/NotificationHandler.kt
@@ -156,7 +156,7 @@ class NotificationHandler(val context: Context) {
         // Create an explicit intent for an Activity in your app
         val intent = when (notificationType) {
             DocumentNotificationType.EXPORT -> {
-                DocumentViewerActivity.newInstance(context, DocumentViewerLaunchViewType.PDFS)
+                DocumentViewerActivity.newInstance(context, DocumentViewerLaunchViewType.EXPORTS)
             }
             DocumentNotificationType.UPLOAD -> {
                 DocumentViewerActivity.newInstance(context, DocumentViewerLaunchViewType.DOCUMENTS)

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/docviewer/DocumentViewerActivity.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/docviewer/DocumentViewerActivity.kt
@@ -157,18 +157,23 @@ class DocumentViewerActivity : BaseNavigationActivity(), View.OnClickListener {
         val type =
             intent.getSerializableExtra(EXTRA_DOCUMENT_VIEWER_LAUNCH_VIEW) as? DocumentViewerLaunchViewType
 
-        // a navigation case when user wants to directly open the images fragment
-        if (documentPage != null) {
-            navController.navigate(
-                DocumentsFragmentDirections.actionViewerDocumentsToViewerImages(documentPage)
-            )
-        } else {
-            when (type) {
-                DocumentViewerLaunchViewType.PDFS -> {
-                    navController.navigate(DocumentsFragmentDirections.actionViewerDocumentsToViewerExports())
-                }
-                else -> {
-                    // ignore
+        // direct navigation to images or exports
+        // the destination check is necessary, otherwise, if the current activity is re-created
+        // and another fragment than DocumentsFragment is currently shown, then the app would crash,
+        // since the direction actions would be wrong for the image fragment.
+        if (navController.currentDestination?.id == R.id.viewer_documents) {
+            if (documentPage != null) {
+                navController.navigate(
+                    DocumentsFragmentDirections.actionViewerDocumentsToViewerImages(documentPage)
+                )
+            } else {
+                when (type) {
+                    DocumentViewerLaunchViewType.EXPORTS -> {
+                        navController.navigate(DocumentsFragmentDirections.actionViewerDocumentsToViewerExports())
+                    }
+                    else -> {
+                        // ignore
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Fixes #33 by adding a destination check before the navigation itself to ensure that the graph navigations performed in `DocumentViewerActivity.kt` onCreate's method are only performed if the current destination equals to the DocumentsFragment (for which the follow-up navigation actions are intended). The crash happens because if the `DocumentViewerActivity.kt` is re-created and the recently shown fragment is different than `DocumentsFragment`, then the re-creation will already also re-create the recently shown fragment, but the activities onCreate func will still try to perform the navigation that is just designed to work if the user goes from the Document->Images/Export. Therefore, the navigation graph cannot find that particular navigation action as the current destination is not the DocumentsFragment in that case.
- Fixes the preliminary check for the migration on devices < android 8 by forcing the target folder to be created before the usable space is determined.