### PR TITLE
fixes duplicated image creation during v1.80.X migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "at.ac.tuwien.caa.docscan"
         minSdkVersion 21
         targetSdkVersion 31
-        versionCode 167
-        versionName "1.8.0"
+        versionCode 169
+        versionName "1.8.2"
 
 //		this is used to show the build time in the AboutActivity
         buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
@@ -205,12 +205,12 @@ dependencies {
     implementation 'me.drakeet.support:toastcompat:1.1.0'
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
 
-    implementation 'androidx.core:core-splashscreen:1.0.0-beta01'
+    implementation 'androidx.core:core-splashscreen:1.0.0-beta02'
 
     // firebase/google related libs
-    implementation 'com.google.firebase:firebase-core:20.1.1'
-    implementation 'com.google.firebase:firebase-crashlytics:18.2.9'
-    implementation 'com.google.firebase:firebase-analytics:20.1.1'
+    implementation 'com.google.firebase:firebase-core:20.1.2'
+    implementation 'com.google.firebase:firebase-crashlytics:18.2.10'
+    implementation 'com.google.firebase:firebase-analytics:20.1.2'
     // uses the "thin" variant, i.e. app size is reduced but dependencies are downloaded after app install.
     implementation 'com.google.android.gms:play-services-mlkit-text-recognition:18.0.0'
 
@@ -225,7 +225,7 @@ dependencies {
     implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: retrofit_version
     implementation group: 'com.squareup.retrofit2', name: 'converter-gson', version: retrofit_version
     // okhttp client
-    def okhttp_version = "4.9.1"
+    def okhttp_version = "4.9.3"
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,9 @@
         <activity
             android:name=".ui.start.StartActivity"
             android:exported="true"
-            android:theme="@style/Theme.App.Starting">
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.App.Starting"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/DocumentDao.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/DocumentDao.kt
@@ -71,7 +71,7 @@ interface DocumentDao {
     fun setDocumentActive(documentId: UUID)
 
     @Query("SELECT * FROM ${Document.TABLE_NAME_DOCUMENTS} WHERE ${Document.KEY_TITLE} =:documentTitle")
-    fun getDocumentsByTitle(documentTitle: String): List<Document>
+    suspend fun getDocumentsByTitle(documentTitle: String): List<Document>
 
     @Query("UPDATE ${Document.TABLE_NAME_DOCUMENTS} SET ${Document.KEY_LOCK_STATE} = :state WHERE ${Document.KEY_ID} = :documentId")
     fun setDocumentLock(documentId: UUID, state: LockState)

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/repository/DocumentRepository.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/repository/DocumentRepository.kt
@@ -376,7 +376,7 @@ class DocumentRepository(
     }
 
     @WorkerThread
-    fun createDocument(document: Document): Resource<Document> {
+    suspend fun createDocument(document: Document): Resource<Document> {
         Timber.i("create document")
         return createOrUpdateDocument(document)
     }
@@ -390,7 +390,7 @@ class DocumentRepository(
     }
 
     @WorkerThread
-    private fun createOrUpdateDocument(document: Document): Resource<Document> {
+    private suspend fun createOrUpdateDocument(document: Document): Resource<Document> {
         val docsByNewTitle = documentDao.getDocumentsByTitle(documentTitle = document.title)
         return if (docsByNewTitle.isEmpty() || (docsByNewTitle.size == 1 && docsByNewTitle[0].id == document.id)) {
             db.runInTransaction {

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/repository/migration/MigrationRepository.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/repository/migration/MigrationRepository.kt
@@ -66,6 +66,7 @@ class MigrationRepository(
      */
     suspend fun migrateJsonDataToDatabase(context: Context): Resource<Unit> {
         if (!preferencesHandler.shouldPerformDBMigration) {
+            Timber.i("Migration is skipped, since it already has been performed!")
             return Success(Unit)
         }
 
@@ -84,6 +85,7 @@ class MigrationRepository(
         // if the document storage file does not exist, then we cannot do anything about it.
         if (!documentStorageFile.safeExists()) {
             preferencesHandler.shouldPerformDBMigration = false
+            Timber.e("Migration is not performed, since documentstorage.json is missing!")
             return Success(Unit)
         }
 
@@ -128,6 +130,7 @@ class MigrationRepository(
                     } else {
                         null
                     }
+                    Timber.i("Creating new doc with id $newDocId")
                     Document(
                         newDocId,
                         title,
@@ -251,6 +254,7 @@ class MigrationRepository(
         File(context.filesDir, "syncinfo.txt").safelyDelete()
         File(context.filesDir, "crop_log.txt").safelyDelete()
 
+        Timber.e("Migration has successfully ended!")
         return Success(Unit)
     }
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/dialog/ADialog.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/dialog/ADialog.kt
@@ -217,6 +217,12 @@ class ADialog : AppCompatDialogFragment() {
             negativeBtn = R.string.dialog_cancel_text,
             isCancellable = false
         ),
+        MIGRATION_ABORT(
+            R.string.abort_migration_title,
+            R.string.abort_migration_text,
+            positiveBtn = R.string.dialog_btn_abort_migration,
+            negativeBtn = R.string.dialog_cancel_text
+        ),
         RATIONALE_MIGRATION_PERMISSION(
             R.string.start_permission_title,
             R.string.start_permission_text,

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/start/StartActivity.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/start/StartActivity.kt
@@ -64,6 +64,14 @@ class StartActivity : BaseActivity() {
         viewModel.checkStartUpConditions(Bundle())
     }
 
+    override fun onBackPressed() {
+        if (viewModel.loadingProgress.value == true) {
+            showDialog(ADialog.DialogAction.MIGRATION_ABORT)
+        } else {
+            super.onBackPressed()
+        }
+    }
+
     private fun observe() {
         viewModel.loadingProgress.observe(this) {
             binding.progress.visibility = if (it) View.VISIBLE else View.GONE
@@ -144,6 +152,12 @@ class StartActivity : BaseActivity() {
                         finish()
                     } else if (dialogResult.isNegative()) {
                         logViewModel.shareLog()
+                    }
+                }
+                ADialog.DialogAction.MIGRATION_ABORT -> {
+                    if (dialogResult.isPositive()) {
+                        Timber.w("User aborted migration!")
+                        finish()
                     }
                 }
                 else -> {

--- a/app/src/main/res/layout/main_container_view.xml
+++ b/app/src/main/res/layout/main_container_view.xml
@@ -7,10 +7,28 @@
     android:orientation="vertical"
     android:paddingBottom="32dp">
 
-    <ProgressBar
+    <LinearLayout
         android:id="@+id/progress"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:indeterminateTint="@color/colorAccent" />
+        android:layout_margin="8dp"
+        android:background="@color/white"
+        android:orientation="vertical"
+        android:padding="8dp">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="8dp"
+            android:indeterminateTint="@color/colorAccent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/migration_loading_text" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="dialog_btn_upload_again">Upload again</string>
     <string name="dialog_btn_cancel_upload">Cancel upload</string>
     <string name="dialog_btn_proceed">Proceed</string>
+    <string name="dialog_btn_abort_migration">Abort Migration</string>
     <string name="dialog_btn_grant_permission">Grant permission</string>
 
     <string name="dialog_delete_image_title_singular">Delete image?</string>
@@ -65,10 +66,15 @@
     <string name="start_migration_dialog_2_title">Data migration</string>
     <string name="start_migration_dialog_2_text">If you proceed, then your image data will be moved from the public storage into the app\'s internal storage. The exporting features have been enhanced to export your data from the app\'s internal storage. Do you want to proceed? This action cannot be undone!</string>
 
+    <string name="abort_migration_title">Abort migration</string>
+    <string name="abort_migration_text">Do you really want to abort the migration and perform it later?</string>
+
     <string name="migration_failed_title">Migration error</string>
     <string name="migration_failed_text">An unknown error has occurred during the migration, please contact the app developer and send us your logs!</string>
     <string name="migration_failed_missing_space_text">The migration has failed, because some of your files could not have been successfully copied to the internal storage. Please ensure that your device has enough storage left and then proceed. If you\'re stuck here, you can also contact us and send us your logs.</string>
     <string name="migration_failed_neg_btn">Send logs</string>
+
+    <string name="migration_loading_text">Your data is being migrated, this might take several minutes.</string>
 
     <string name="start_permission_title">Permission required</string>
     <string name="start_permission_text">The app requires a one-time permission for the storage to perform mandatory data migrations!</string>


### PR DESCRIPTION
- adds checks for MigrationViewModel to not spawn more than one migration job.
- adds abort dialog for the migration to explicitly ask the user when aborting the migration.
- adds an additional UI hint while performing the migration to notify the user that the migration may take a while.
- updates minor dependencies.

Please note that the cancellation of the migration happens implicitly by finishing the activity, the viewModel lies in the scope of the activity and as soon it's destroyed, the viewModelScope gets cancelled.

For testing purposes: A long migration can be easily simulated by adding a `delay(500)` in the MigrationRepository, shortly before a new image is being created.

refs #35