### PR TITLE
#37 fixes endless loading states for exports

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -183,6 +183,7 @@ dependencies {
     implementation "io.insert-koin:koin-android:$koin_version"
     // a compat lib only used for injecting viewModels in a java class
     implementation "io.insert-koin:koin-android-compat:$koin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
 
     // fragment/navigation ktx related libs
     implementation 'androidx.fragment:fragment-ktx:1.4.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "at.ac.tuwien.caa.docscan"
         minSdkVersion 21
         targetSdkVersion 31
-        versionCode 169
-        versionName "1.8.2"
+        versionCode 171
+        versionName "1.8.4"
 
 //		this is used to show the build time in the AboutActivity
         buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"

--- a/app/schemas/at.ac.tuwien.caa.docscan.db.AppDatabase/2.json
+++ b/app/schemas/at.ac.tuwien.caa.docscan.db.AppDatabase/2.json
@@ -1,0 +1,341 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "eb212b14a05d15102806a875268d08cc",
+    "entities": [
+      {
+        "tableName": "documents",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `file_prefix` TEXT, `is_active` INTEGER NOT NULL, `lock_state` TEXT NOT NULL, `transkribus_upload_id` INTEGER, `metadata_related_upload_id` INTEGER, `metadata_author` TEXT, `metadata_authority` TEXT, `metadata_hierarchy` TEXT, `metadata_genre` TEXT, `metadata_language` TEXT, `metadata_is_project_readme_2020` INTEGER, `metadata_allow_image_publication` INTEGER, `metadata_signature` TEXT, `metadata_url` TEXT, `metadata_writer` TEXT, `metadata_description` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePrefix",
+            "columnName": "file_prefix",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lockState",
+            "columnName": "lock_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadId",
+            "columnName": "transkribus_upload_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.relatedUploadId",
+            "columnName": "metadata_related_upload_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.author",
+            "columnName": "metadata_author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.authority",
+            "columnName": "metadata_authority",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.hierarchy",
+            "columnName": "metadata_hierarchy",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.genre",
+            "columnName": "metadata_genre",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.language",
+            "columnName": "metadata_language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.isProjectReadme2020",
+            "columnName": "metadata_is_project_readme_2020",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.allowImagePublication",
+            "columnName": "metadata_allow_image_publication",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.signature",
+            "columnName": "metadata_signature",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.url",
+            "columnName": "metadata_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.writer",
+            "columnName": "metadata_writer",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metaData.description",
+            "columnName": "metadata_description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "pages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `doc_id` TEXT NOT NULL, `file_hash` TEXT NOT NULL, `index` INTEGER NOT NULL, `rotation` INTEGER NOT NULL, `file_type` TEXT NOT NULL, `post_processing_state` TEXT NOT NULL, `export_state` TEXT NOT NULL, `legacy_absolute_file_path` TEXT, `spbtop_leftx` REAL, `spbtop_lefty` REAL, `spbtop_rightx` REAL, `spbtop_righty` REAL, `spbbottom_leftx` REAL, `spbbottom_lefty` REAL, `spbbottom_rightx` REAL, `spbbottom_righty` REAL, `uploadupload_state` TEXT NOT NULL, `uploadupload_file_name` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "docId",
+            "columnName": "doc_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileHash",
+            "columnName": "file_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rotation",
+            "columnName": "rotation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postProcessingState",
+            "columnName": "post_processing_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exportState",
+            "columnName": "export_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "legacyFilePath",
+            "columnName": "legacy_absolute_file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.topLeft.x",
+            "columnName": "spbtop_leftx",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.topLeft.y",
+            "columnName": "spbtop_lefty",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.topRight.x",
+            "columnName": "spbtop_rightx",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.topRight.y",
+            "columnName": "spbtop_righty",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.bottomLeft.x",
+            "columnName": "spbbottom_leftx",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.bottomLeft.y",
+            "columnName": "spbbottom_lefty",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.bottomRight.x",
+            "columnName": "spbbottom_rightx",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singlePageBoundary.bottomRight.y",
+            "columnName": "spbbottom_righty",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "transkribusUpload.state",
+            "columnName": "uploadupload_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transkribusUpload.uploadFileName",
+            "columnName": "uploadupload_file_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `user_name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "export_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`file_name` TEXT NOT NULL, `doc_id` TEXT NOT NULL DEFAULT 'd0289e3b-f7f3-4e9b-8eb8-6f392c503f51', `file_uri` TEXT, `is_processing` INTEGER NOT NULL, PRIMARY KEY(`file_name`))",
+        "fields": [
+          {
+            "fieldPath": "fileName",
+            "columnName": "file_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "docId",
+            "columnName": "doc_id",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'d0289e3b-f7f3-4e9b-8eb8-6f392c503f51'"
+          },
+          {
+            "fieldPath": "fileUri",
+            "columnName": "file_uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isProcessing",
+            "columnName": "is_processing",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "file_name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eb212b14a05d15102806a875268d08cc')"
+    ]
+  }
+}

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/DocScanApp.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/DocScanApp.kt
@@ -57,7 +57,7 @@ class DocScanApp : Application() {
         // initializes notification channels
         notificationHandler.initNotificationChannels()
         // spawn the sanitizer to check potential broken states
-        DocumentSanitizeWorker.spawnSanitize(workManager)
+        DocumentSanitizeWorker.sanitizeWorkerJobs(this, notificationHandler, workManager)
         logFirstAppStart()
     }
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/camera/CameraPreview.java
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/camera/CameraPreview.java
@@ -571,7 +571,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         } catch (RuntimeException e) {
             //            This can happen if the user touches the CameraPreview, while the preview is not
             //            started. In this case we do nothing.
-            Timber.e(e);
+            Timber.w("Auto focus has failed!");
         }
 
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/AppDatabase.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/AppDatabase.kt
@@ -1,10 +1,7 @@
 package at.ac.tuwien.caa.docscan.db
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.room.TypeConverters
+import androidx.room.*
 import at.ac.tuwien.caa.docscan.db.converter.DatabaseTypeConverter
 import at.ac.tuwien.caa.docscan.db.dao.DocumentDao
 import at.ac.tuwien.caa.docscan.db.dao.ExportFileDao
@@ -17,7 +14,11 @@ import at.ac.tuwien.caa.docscan.db.model.User
 
 @Database(
     entities = [Document::class, Page::class, User::class, ExportFile::class],
-    version = 1
+    version = 2,
+    autoMigrations = [
+        // a minor migration, where just attributes have been added for ExportFile.
+        AutoMigration(from = 1, to = 2)
+    ]
 )
 @TypeConverters(DatabaseTypeConverter::class)
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/converter/DatabaseTypeConverter.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/converter/DatabaseTypeConverter.kt
@@ -1,5 +1,6 @@
 package at.ac.tuwien.caa.docscan.db.converter
 
+import android.net.Uri
 import androidx.room.TypeConverter
 import at.ac.tuwien.caa.docscan.db.model.exif.Rotation
 import at.ac.tuwien.caa.docscan.db.model.state.ExportState
@@ -17,6 +18,18 @@ class DatabaseTypeConverter {
 
     @TypeConverter
     fun fromUUIDtoString(value: UUID): String {
+        return value.toString()
+    }
+
+    @TypeConverter
+    fun fromStringToUri(value: String?): Uri? {
+        value ?: return null
+        return Uri.parse(value)
+    }
+
+    @TypeConverter
+    fun fromUriToString(value: Uri?): String? {
+        value ?: return null
         return value.toString()
     }
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/ExportFileDao.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/ExportFileDao.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import androidx.room.*
 import at.ac.tuwien.caa.docscan.db.model.ExportFile
 import kotlinx.coroutines.flow.Flow
+import java.util.*
 
 @Keep
 @Dao
@@ -26,6 +27,15 @@ interface ExportFileDao {
 
     @Query("SELECT * FROM ${ExportFile.TABLE_NAME_EXPORT_FILES}")
     suspend fun getExportFiles(): List<ExportFile>
+
+    @Query("SELECT * FROM ${ExportFile.TABLE_NAME_EXPORT_FILES} WHERE ${ExportFile.KEY_DOC_ID} = :docId AND ${ExportFile.KEY_IS_PROCESSING} = 1")
+    suspend fun getProcessingExportFiles(docId: UUID): List<ExportFile>
+
+    @Query("UPDATE ${ExportFile.TABLE_NAME_EXPORT_FILES} SET ${ExportFile.KEY_IS_PROCESSING}= :isProcessing WHERE ${ExportFile.KEY_FILE_NAME} = :id")
+    suspend fun updateProcessingState(id: String, isProcessing: Boolean)
+
+    @Query("UPDATE ${ExportFile.TABLE_NAME_EXPORT_FILES} SET ${ExportFile.KEY_IS_PROCESSING} = 0")
+    suspend fun updatesAllProcessingStatesToFalse()
 
     @Query("SELECT COUNT(*) FROM ${ExportFile.TABLE_NAME_EXPORT_FILES} WHERE ${ExportFile.KEY_IS_PROCESSING} = 0")
     fun getExportFileCount(): Flow<Long>

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/PageDao.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/dao/PageDao.kt
@@ -24,11 +24,11 @@ interface PageDao {
     @Query("SELECT * FROM ${Page.TABLE_NAME_PAGES} WHERE ${Page.KEY_ID} = :id")
     suspend fun getPageById(id: UUID): Page?
 
-    @Query("SELECT * FROM ${Page.TABLE_NAME_PAGES} WHERE ${Page.KEY_LEGACY_ABSOLUTE_FILE_PATH} = :legacyFilePath AND ${Page.KEY_DOC_ID} = :docId")
-    suspend fun getPageByLegacyFilePath(docId: UUID, legacyFilePath: String): List<Page>
-
     @Query("SELECT * FROM ${Page.TABLE_NAME_PAGES} WHERE ${Page.KEY_ID} = :id")
     fun getPageByIdNonSuspendable(id: UUID): Page?
+
+    @Query("SELECT * FROM ${Page.TABLE_NAME_PAGES} WHERE ${Page.KEY_LEGACY_ABSOLUTE_FILE_PATH} = :legacyFilePath AND ${Page.KEY_DOC_ID} = :docId")
+    suspend fun getPageByLegacyFilePath(docId: UUID, legacyFilePath: String): List<Page>
 
     @Query("SELECT * FROM ${Page.TABLE_NAME_PAGES} WHERE ${Page.KEY_DOC_ID} = :docId")
     suspend fun getPagesByDoc(docId: UUID): List<Page>

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/model/Document.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/model/Document.kt
@@ -77,11 +77,13 @@ private fun Document.fileNamePrefix(pageNumber: Int): String {
     filePrefix?.let {
         if (it.isNotEmpty()) {
             return Helper.getFileNamePrefix(
-                Helper.getFileTimeStamp(), it, pageNumber)
+                Helper.getFileTimeStamp(), it, pageNumber
+            )
         }
     }
     return Helper.getFileNamePrefix(
-        Helper.getFileTimeStamp(), sanitizedTitle(), pageNumber)
+        Helper.getFileTimeStamp(), sanitizedTitle(), pageNumber
+    )
 }
 
 fun Document.edit(title: String, prefix: String?, metaData: MetaData?): Document {

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/db/model/ExportFile.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/db/model/ExportFile.kt
@@ -1,23 +1,52 @@
 package at.ac.tuwien.caa.docscan.db.model
 
+import android.net.Uri
 import androidx.annotation.Keep
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.*
 
 @Keep
 @Entity(tableName = ExportFile.TABLE_NAME_EXPORT_FILES)
 data class ExportFile(
+
+    /**
+     * A unique file name. The uniqueness of file names is automatically ensured by the android
+     * system for a specific folder.
+     */
     @PrimaryKey
     @ColumnInfo(name = KEY_FILE_NAME)
     val fileName: String,
+    /**
+     * The corresponding documentId, this is not unique as there might be several different exports
+     * for a single document.
+     * - the default value is just an arbitrary id in order to prevent making the field nullable,
+     * but for already created exports, this field doesn't matter anyway.
+     */
+    @ColumnInfo(name = KEY_DOC_ID, defaultValue = "d0289e3b-f7f3-4e9b-8eb8-6f392c503f51")
+    val docId: UUID,
+    /**
+     * The corresponding fileUri where the export is going to placed, this is only available for
+     * a short period of time while the document is being exported.
+     *
+     * Please note that this fileUri should be only used for clean-ups if the export has been interrupted
+     * in an unexpected way.
+     */
+    @ColumnInfo(name = KEY_FILE_URI)
+    val fileUri: Uri?,
+    /**
+     * A boolean flag that indicates if the export file is being processed.
+     */
     @ColumnInfo(name = KEY_IS_PROCESSING)
     val isProcessing: Boolean
 ) {
     companion object {
 
         const val TABLE_NAME_EXPORT_FILES = "export_files"
+        const val KEY_DOC_ID = "doc_id"
         const val KEY_FILE_NAME = "file_name"
+        const val KEY_FILE_URI = "file_uri"
         const val KEY_IS_PROCESSING = "is_processing"
     }
 }

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/export/PdfCreator.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/export/PdfCreator.kt
@@ -14,6 +14,7 @@ import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.Text
 import com.google.mlkit.vision.text.Text.TextBlock
 import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.itextpdf.text.*
 import com.itextpdf.text.pdf.BaseFont
@@ -27,10 +28,16 @@ import java.io.File
 
 object PdfCreator {
 
-    suspend fun analyzeFileWithOCR(context: Context, uri: Uri): Resource<Text> {
+    suspend fun analyzeFileWithOCR(
+        context: Context,
+        uri: Uri,
+        textRecognizer: TextRecognizer = TextRecognition.getClient(
+            TextRecognizerOptions.DEFAULT_OPTIONS
+        )
+    ): Resource<Text> {
         @Suppress("BlockingMethodInNonBlockingContext")
         val image = InputImage.fromFilePath(context, uri)
-        val task = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS).process(image)
+        val task = textRecognizer.process(image)
         return task.await()
     }
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/koin/KoinModule.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/koin/KoinModule.kt
@@ -90,7 +90,7 @@ val viewModelModule = module {
 }
 
 val repositoryModule = module {
-    single { DocumentRepository(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    single { DocumentRepository(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single { UserRepository(get(), get(), get(), get(), get()) }
     single { UploadRepository(get(), get(), get(), get(), get()) }
     single { ExportRepository(get(), get(), get(), get(), get(), get()) }

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/logic/notification/NotificationHandler.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/logic/notification/NotificationHandler.kt
@@ -212,6 +212,16 @@ class NotificationHandler(val context: Context) {
         getNotificationManager(context).cancel(tag, notificationId)
     }
 
+    fun cancelAllNotificationsByChannel(channel: DocScanNotificationChannel) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getNotificationManager(context).activeNotifications.forEach { statusBarNotification ->
+                if (statusBarNotification.tag == channel.tag) {
+                    cancelNotification(statusBarNotification.tag, statusBarNotification.id)
+                }
+            }
+        }
+    }
+
     fun cancelNotificationByGroup(groupKey: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             getNotificationManager(context).activeNotifications.forEach { statusBarNotification ->

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/repository/ExportFileRepository.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/repository/ExportFileRepository.kt
@@ -1,9 +1,11 @@
 package at.ac.tuwien.caa.docscan.repository
 
+import android.net.Uri
 import at.ac.tuwien.caa.docscan.db.dao.ExportFileDao
 import at.ac.tuwien.caa.docscan.db.model.ExportFile
 import at.ac.tuwien.caa.docscan.ui.docviewer.pdf.ExportList
 import at.ac.tuwien.caa.docscan.ui.docviewer.pdf.ExportState
+import java.util.*
 
 class ExportFileRepository(
     private val exportFileDao: ExportFileDao
@@ -14,7 +16,7 @@ class ExportFileRepository(
             .filter { exportFile -> files.firstOrNull { file -> file.name == exportFile.fileName } == null }
         exportFileDao.delete(notFoundFiles)
 
-        // 2. loop through each requested file and check if it's name is in the DB.
+        // 2. loop through each requested file and check if its name is in the DB.
         files.forEach { file ->
             val exportFile = exportFileDao.getExportFileByFileName(file.name).firstOrNull()
             val exportState: ExportState = when {
@@ -33,8 +35,20 @@ class ExportFileRepository(
         return files
     }
 
-    suspend fun insertOrUpdateFile(fileName: String, isProcessing: Boolean) {
-        exportFileDao.insertExportFile(ExportFile(fileName = fileName, isProcessing = isProcessing))
+    suspend fun insertOrUpdateFile(
+        docId: UUID,
+        fileName: String,
+        fileUri: Uri?,
+        isProcessing: Boolean
+    ) {
+        exportFileDao.insertExportFile(
+            ExportFile(
+                fileName = fileName,
+                docId = docId,
+                fileUri = fileUri,
+                isProcessing = isProcessing
+            )
+        )
     }
 
     suspend fun removeAll() {

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/repository/ImageResourceHelper.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/repository/ImageResourceHelper.kt
@@ -4,8 +4,6 @@ import at.ac.tuwien.caa.docscan.db.model.Page
 import at.ac.tuwien.caa.docscan.logic.Failure
 import at.ac.tuwien.caa.docscan.logic.Resource
 import at.ac.tuwien.caa.docscan.logic.Success
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.*
 
@@ -15,33 +13,31 @@ import java.util.*
  * - [imageOperation] runs the operation on the file of the image and returns a result that should be persisted in the page object.
  * - [postOperation] runs after the [imageOperation] to perform DB updates, but it is always performed to cleanup possible errors.
  */
-suspend fun <T> pageImageOperation(
+fun <T> pageImageOperation(
     pageId: UUID,
-    preOperation: suspend () -> Resource<Pair<Page, File>>,
-    imageOperation: suspend (page: Page, file: File) -> Resource<T>,
-    postOperation: suspend (page: UUID, operationResource: Resource<T>) -> Unit
+    preOperation: () -> Resource<Pair<Page, File>>,
+    imageOperation: (page: Page, file: File) -> Resource<T>,
+    postOperation: (page: UUID, operationResource: Resource<T>) -> Unit
 ): Resource<Unit> {
-    return withContext(NonCancellable) {
-        val input = when (val pre = preOperation.invoke()) {
-            is Failure -> {
-                // call the post operation on an error too to cleanup states/resources
-                postOperation.invoke(pageId, Failure(pre.exception))
-                return@withContext Failure(pre.exception)
-            }
-            is Success -> {
-                pre.data
-            }
+    val input = when (val pre = preOperation.invoke()) {
+        is Failure -> {
+            // call the post operation on an error too to cleanup states/resources
+            postOperation.invoke(pageId, Failure(pre.exception))
+            return Failure(pre.exception)
         }
-        val result = imageOperation.invoke(input.first, input.second)
-        postOperation.invoke(pageId, result)
+        is Success -> {
+            pre.data
+        }
+    }
+    val result = imageOperation.invoke(input.first, input.second)
+    postOperation.invoke(pageId, result)
 
-        when (result) {
-            is Failure -> {
-                return@withContext Failure<Unit>(result.exception)
-            }
-            is Success -> {
-                return@withContext Success(Unit)
-            }
+    return when (result) {
+        is Failure -> {
+            Failure(result.exception)
+        }
+        is Success -> {
+            Success(Unit)
         }
     }
 }

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/ui/docviewer/pdf/ExportViewModel.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/ui/docviewer/pdf/ExportViewModel.kt
@@ -39,8 +39,6 @@ class ExportViewModel(
                     folderUri.toString()
                 )
             ) {
-                val systemMilliSeconds = System.currentTimeMillis()
-                Timber.d("DOCUMENTS")
                 val list = mutableListOf<ExportList>()
 //            val header = ExportList.ExportHeader(folderUri.path ?: "Unknown path!")
                 val files = exportFileRepository.checkFileNames(
@@ -55,14 +53,12 @@ class ExportViewModel(
                             file.displayName
                         )
                     })
-                Timber.d("DOCUMENTS - ${System.currentTimeMillis() - systemMilliSeconds}")
 //            list.add(header)
                 list.addAll(files.sortedByDescending { file -> file.file.lastModified })
-                Timber.d("DOCUMENTS - ${System.currentTimeMillis() - systemMilliSeconds}")
 
                 observableExportModel.postValue(ExportModel.Success(list, scrollToTop))
             } else {
-                observableExportModel.postValue(ExportModel.MissingPermissions())
+                observableExportModel.postValue(ExportModel.MissingPermissions)
             }
         }
     }
@@ -120,7 +116,7 @@ class ExportViewModel(
 }
 
 sealed class ExportModel {
-    class MissingPermissions : ExportModel()
+    object MissingPermissions : ExportModel()
     class Success(val exportEntries: List<ExportList>, val scrollToTop: Boolean) : ExportModel()
 }
 

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/worker/DocumentSanitizeWorker.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/worker/DocumentSanitizeWorker.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.work.*
 import at.ac.tuwien.caa.docscan.logic.Failure
 import at.ac.tuwien.caa.docscan.logic.Success
+import at.ac.tuwien.caa.docscan.logic.notification.DocScanNotificationChannel
+import at.ac.tuwien.caa.docscan.logic.notification.NotificationHandler
 import at.ac.tuwien.caa.docscan.repository.DocumentRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -39,9 +41,33 @@ class DocumentSanitizeWorker(
         const val ID = "c5c52f8b-f238-484e-b988-1f635d06fa4e"
 
         /**
-         * Spawns a new worker job that executes [DocumentRepository.sanitizeDocuments].
+         * Sanitizes DB states in the app:
+         * - Cancels all enqueued [ExportWorker] jobs.
+         * - Cancels all notifications for channel [DocScanNotificationChannel.CHANNEL_EXPORT].
+         * - Spawns a sanitize worker, that will run [DocumentRepository.sanitizeDocuments]
          */
-        fun spawnSanitize(workManager: WorkManager) {
+        fun sanitizeWorkerJobs(
+            context: Context,
+            notificationHandler: NotificationHandler,
+            workManager: WorkManager
+        ) {
+
+            // cancel all export notifications as they will be cancelled
+            notificationHandler.cancelAllNotificationsByChannel(DocScanNotificationChannel.CHANNEL_EXPORT)
+
+            // worker jobs that have not been running when the app was killed, will be still enqueued
+            // and might be called at a later time.
+            // - enqueued export jobs will be cancelled, as their state is reset in sanitizeDocuments, since
+            // they are not designed to be restarted.
+            getCurrentWorkerJobStates(
+                context, listOf(
+                    ExportWorker.EXPORT_TAG
+                ), states = listOf(WorkInfo.State.ENQUEUED)
+            ).forEach {
+                Timber.i("Cancelling worker job $it")
+                workManager.cancelWorkById(it.jobId)
+            }
+
             val sanitizeDocumentsRequest =
                 OneTimeWorkRequest.Builder(DocumentSanitizeWorker::class.java)
                     // please note, to not add multiple tags (see getCurrentWorkerJobStates for more info)

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/worker/DocumentSanitizeWorker.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/worker/DocumentSanitizeWorker.kt
@@ -38,6 +38,9 @@ class DocumentSanitizeWorker(
         const val TAG = "document_sanitizer"
         const val ID = "c5c52f8b-f238-484e-b988-1f635d06fa4e"
 
+        /**
+         * Spawns a new worker job that executes [DocumentRepository.sanitizeDocuments].
+         */
         fun spawnSanitize(workManager: WorkManager) {
             val sanitizeDocumentsRequest =
                 OneTimeWorkRequest.Builder(DocumentSanitizeWorker::class.java)

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/worker/UploadWorker.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/worker/UploadWorker.kt
@@ -135,6 +135,7 @@ class UploadWorker(
             documentId: UUID,
             allowMobileData: Boolean
         ) {
+            Timber.i("Requesting WorkManager to queue UploadWorker for docId $documentId")
             val uploadImages = OneTimeWorkRequest.Builder(UploadWorker::class.java)
                 // please note, to not add multiple tags (see getCurrentWorkerJobStates for more info)
                 .addTag(UPLOAD_TAG)
@@ -155,7 +156,6 @@ class UploadWorker(
                 )
                 .build()
 
-            Timber.i("Requesting WorkManager to queue UploadWorker")
             workManager.enqueueUniqueWork(
                 getWorkNameByDocId(documentId),
                 ExistingWorkPolicy.KEEP,

--- a/app/src/main/java/at/ac/tuwien/caa/docscan/worker/WorkerManagerHelper.kt
+++ b/app/src/main/java/at/ac/tuwien/caa/docscan/worker/WorkerManagerHelper.kt
@@ -37,4 +37,8 @@ fun getCurrentWorkerJobStates(
     return docScanWorkInfos.sortedBy { docScanWorkInfo -> docScanWorkInfo.tag }
 }
 
-data class DocScanWorkInfo(val tag: String, val jobId: UUID, val workInfo: WorkInfo)
+data class DocScanWorkInfo(val tag: String, val jobId: UUID, val workInfo: WorkInfo) {
+    override fun toString(): String {
+        return "DocScanWorkInfo{tag=${tag}, jobId=${jobId}, workInfo=$workInfo}}"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ ext {
 buildscript {
 
     ext {
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.6.21'
         koin_version = "3.1.5"
         nav_version = "2.4.1"
     }
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 


### PR DESCRIPTION
Fixes and improves the export feature in the app.

Technical changes:
- Adds two new fields for the migration of the table `export_files`:
   - `docId` in order to find the associated doc for the export file.
   - `fileUri` the real uri which is used to save the export that can be used to clean-up the most likely corrupted export file.
Both of the newly introduced values doesn't need to have a specific migration value as they are just relevant for ongoing exports.

Improvements and changes of the export:
- If the app is killed & restarted, then all enqueued export jobs will be immediately cancelled. Already running jobs that have been interrupted will not restart on their own. The export notifications are then cancelled in that case.
- The loading states on the export tab are now correctly handled.
- Possible zombie files for exports that have been cancelled or interrupted are removed during the app start within the sanitize worker job.
- The OCR scan in the app is now performed one-by-one as previously multiple IO threads were spawned which caused the entire phone to be very unresponsive. I think that this was also the reason why one of our users tried to kill the app during the export as the phone become so unresponsive.
   - I also played around with limited threads, but I couldn't see any performance boost, I think the bottle neck lies in the executor of the text recognition lib.
- The cropping operation now also limits the number of parallel threads to 4 as it caused similar issue like the OCR scan.
